### PR TITLE
New ops

### DIFF
--- a/modules/Code/Annotation/AnnotatedTypeCastExpression.cs
+++ b/modules/Code/Annotation/AnnotatedTypeCastExpression.cs
@@ -1,0 +1,22 @@
+using System;
+using swifty.Code.Syntaxt;
+
+namespace swifty.Code.Annotation {
+    internal sealed class AnnotatedTypeCastExpression : AnnotatedExpression {
+        public AnnotatedTypeCastExpression(AnnotatedExpression left, SyntaxKind right) {
+            Left = left;
+            Right = right;
+        }
+        public override AnnotatedKind Kind => AnnotatedKind.LiteralExpression;
+        public override Type Type => GetResultType();
+        public AnnotatedExpression Left {get;}
+        public SyntaxKind Right {get;}
+        public Type GetResultType() {
+            switch (Right) {
+                case SyntaxKind.BoolKeyword: return typeof(bool);
+                case SyntaxKind.IntKeyword: return typeof(int);
+                default: return typeof(object);
+            }
+        }
+    }
+}

--- a/modules/Code/Annotation/Annotator.cs
+++ b/modules/Code/Annotation/Annotator.cs
@@ -41,6 +41,7 @@ namespace swifty.Code.Annotation {
         public DiagnosisHandler Diagnostics => _diagnostics;
         public AnnotatedExpression AnnotateExpression(ExpressionSyntax syntax) {
             switch(syntax.Kind) {
+                case SyntaxKind.TypeCastExpression: return AnnotateTypeCastExpression((TypeCastExpressionSyntax)syntax);
                 case SyntaxKind.BinaryExpression: return AnnotateBinaryExpression((BinaryExpressionSyntax)syntax);
                 case SyntaxKind.UnaryExpression: return AnnotateUnaryExpression((UnaryExpressionSyntax)syntax);
                 case SyntaxKind.LiteralExpression: return AnnotateLiteralExpression((LiteralExpressionSyntax)syntax);
@@ -121,6 +122,11 @@ namespace swifty.Code.Annotation {
         public AnnotatedStatement AnnotateExpressionStatement(ExpressionStatementSyntax statement) {
             var expression = AnnotateExpression(statement.Expression);
             return new AnnotatedExpressionStatement(expression);
+        }
+        private AnnotatedExpression AnnotateTypeCastExpression(TypeCastExpressionSyntax syntax) {
+            var left = AnnotateExpression(syntax.Operand);
+            var right = syntax.Type.Kind;
+            return new AnnotatedTypeCastExpression(left, right);
         }
         public AnnotatedExpression AnnotateNameExpression(NameExpressionSyntax syntax) {
             var name = syntax.IdentifierToken.Text;

--- a/modules/Code/Evaluator.cs
+++ b/modules/Code/Evaluator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using swifty.Code.Annotation;
+using swifty.Code.Syntaxt;
 
 namespace swifty.Code {
     internal class Evaluator {
@@ -59,6 +60,10 @@ namespace swifty.Code {
             throw new Exception($"Unexpected node {statement.Kind}");
         }
         private object EvaluateExpression(AnnotatedExpression root) {
+            if (root is AnnotatedTypeCastExpression t) {
+                var left = EvaluateExpression(t.Left);
+                return PerformTypeCast(left, t.Right);
+            }
             if (root is AnnotatedLiteralExpression n) {
                 return n.Value;
             }
@@ -109,6 +114,19 @@ namespace swifty.Code {
                 }
             }
             throw new Exception($"Unexpected node {root.Kind}");
+        }
+        private object PerformTypeCast(object left, SyntaxKind right) {
+            if (left.GetType() == typeof(int) && right == SyntaxKind.BoolKeyword) {
+                return (int)left != 0;
+            }
+            if (left.GetType() == typeof(bool) && right == SyntaxKind.IntKeyword) {
+                return (bool)left ? 1 : 0;
+            }
+            if ((left.GetType() == typeof(int) && right == SyntaxKind.IntKeyword) || (left.GetType() == typeof(bool) && right == SyntaxKind.BoolKeyword)) {
+                return left;
+            }
+            Console.WriteLine("Typecast failed");
+            return -1;
         }
     }
 }

--- a/modules/Code/Syntax/Lexer.cs
+++ b/modules/Code/Syntax/Lexer.cs
@@ -47,7 +47,6 @@ namespace swifty.Code.Syntaxt {
             while (Current != '\0' && Current != '\n') Next();
             int len = _position - start;
             string comment = _text.ToString(start, len);
-            Console.WriteLine(comment);
             return new SyntaxToken(SyntaxKind.CommentToken, start, comment, null);
         }
         private SyntaxToken ReadNumber() {
@@ -126,6 +125,10 @@ namespace swifty.Code.Syntaxt {
                     if (LookAhead=='=') {
                         _position += 2;
                         return new SyntaxToken(SyntaxKind.EqualToken, _position-2, "==", null);
+                    }
+                    if (LookAhead=='>') {
+                        _position += 2;
+                        return new SyntaxToken(SyntaxKind.TypeCastToken, _position-2, "=>", null);
                     }
                     break;
                 }

--- a/modules/Code/Syntax/Parser.cs
+++ b/modules/Code/Syntax/Parser.cs
@@ -104,12 +104,7 @@ namespace swifty.Code.Syntaxt {
                 constKeyword = NextToken();
             }
             bool isReadonly = (constKeyword==null ? false : true);
-            SyntaxToken datatypeKeyword;
-            switch(Current.Kind) {
-                case SyntaxKind.IntKeyword : datatypeKeyword = MatchToken(SyntaxKind.IntKeyword); break;
-                case SyntaxKind.BoolKeyword: datatypeKeyword = MatchToken(SyntaxKind.BoolKeyword); break;
-                default: datatypeKeyword = MatchToken(SyntaxKind.KeywordToken); break;
-            }
+            SyntaxToken datatypeKeyword = FetchDataType();
             var identifier = MatchToken(SyntaxKind.IdentifierToken);
             var assignmentToken = MatchToken(SyntaxKind.AssignmentToken);
             var initializer = ParseExpression();
@@ -158,10 +153,24 @@ namespace swifty.Code.Syntaxt {
                 int precedence = Current.Kind.GetBinaryOperatorPrecendence();
                 if (precedence == 0 || precedence <= parentPrecedence) break;
                 SyntaxToken operatorToken = NextToken();
+                if (operatorToken.Kind == SyntaxKind.TypeCastToken) {
+                    SyntaxToken resultantType = FetchDataType();
+                    left = new TypeCastExpressionSyntax(left, operatorToken, resultantType);
+                    continue;
+                }
                 ExpressionSyntax right = ParseBinaryExpression(precedence);
                 left = new BinaryExpressionSyntax(left, operatorToken, right);
             }
             return left;
+        }
+        private SyntaxToken FetchDataType(){
+            SyntaxToken keywordToken;
+            switch(Current.Kind) {
+                case SyntaxKind.IntKeyword : keywordToken = MatchToken(SyntaxKind.IntKeyword); break;
+                case SyntaxKind.BoolKeyword: keywordToken = MatchToken(SyntaxKind.BoolKeyword); break;
+                default: keywordToken = MatchToken(SyntaxKind.KeywordToken); break;
+            }
+            return keywordToken;
         }
         private ExpressionSyntax ParsePrimaryExpression() {
             switch(Current.Kind) {

--- a/modules/Code/Syntax/SyntaxKind.cs
+++ b/modules/Code/Syntax/SyntaxKind.cs
@@ -14,6 +14,7 @@ namespace swifty.Code.Syntaxt {
         LogicalAndToken,
         LogicalOrToken,
         AssignmentToken,
+        TypeCastToken,
         XorToken,
         AndToken,
         OrToken,
@@ -57,5 +58,6 @@ namespace swifty.Code.Syntaxt {
         UnaryExpression,
         NameExpression,
         AssignmentExpression,
+        TypeCastExpression,
     }
 }

--- a/modules/Code/Syntax/SyntaxRules.cs
+++ b/modules/Code/Syntax/SyntaxRules.cs
@@ -2,6 +2,7 @@ namespace swifty.Code.Syntaxt {
     internal static class SyntaxRules {
         internal static int GetBinaryOperatorPrecendence(this SyntaxKind kind) {
             switch(kind) {
+                case SyntaxKind.TypeCastToken:          return 7;
                 case SyntaxKind.OrToken:                return 6;
                 case SyntaxKind.AndToken:               return 6;
                 case SyntaxKind.XorToken:               return 6;

--- a/modules/Code/Syntax/TypeCastExpressionSyntax.cs
+++ b/modules/Code/Syntax/TypeCastExpressionSyntax.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace swifty.Code.Syntaxt {
+    class TypeCastExpressionSyntax : ExpressionSyntax {
+        public TypeCastExpressionSyntax(ExpressionSyntax operand, SyntaxToken op, SyntaxToken type) {
+            Operand = operand;
+            Operator = op;
+            Type = type;
+        }
+        public override SyntaxKind Kind => SyntaxKind.TypeCastExpression;
+        public ExpressionSyntax Operand {get;}
+        public SyntaxToken Operator {get;}
+        public SyntaxToken Type {get;}
+        public override IEnumerable<SyntaxNode> GetChildren() {
+            yield return Operand;
+            yield return Operator;
+            yield return Type;
+        }
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -9,19 +9,21 @@
 
 ## Syntax (Currently Supported)
 ```
-/* Variable declarations */
+# Variable declarations #
 int a := 10
-bool a := true
+bool a := True
 const int a := 10
-const bool b := false
+const bool b := False
 
-/* operators */
+# operators #
 + - * / := & | ^ && || == { } ( ) ! > < >= <= 
+(expression)=>(datatype) :  typecast operator (usage: 10 => bool, True => int)
+                            returns -1 on failure
 
-/* control flows and loops */
-if i > 10 {} else {}       // if else construct
-for int i := 1 to 10 {}    // for loop construct
-while i < 10 {}            // while loop construct
+# control flows and loops #
+if i > 10 {} else {}       # if else construct
+for int i := 1 to 10 {}    # for loop construct
+while i < 10 {}            # while loop construct
 ```
 
 ## Getting everything ready!

--- a/swifty.tests/Code/EvaluatorTests.cs
+++ b/swifty.tests/Code/EvaluatorTests.cs
@@ -15,6 +15,9 @@ namespace swifty.tests.Code.Text {
         [InlineData("{int res:=0\nfor int i:=0 to 10 {\nres:=res+i\n}\n}", 45)]
         [InlineData("const int d := 100 # this is a single line comment!", 100)]
         [InlineData("{int res:=0#kello\nfor int i:=0 to 11 {\nres:=res+i #hello\n}#dello\n}", 55)]
+        [InlineData("1=>bool && 10=>bool", true)]
+        [InlineData("True=>int + 100", 101)]
+        [InlineData("{!((True=>int-1)=>bool)=>int+5}", 6)]
        public void Evaluator_Computes_Correct_Value(string text, object expectedValue) {
            var syntaxTree = SyntaxTree.Parse(text);
            var compiler = new Compiler(syntaxTree);
@@ -37,6 +40,9 @@ namespace swifty.tests.Code.Text {
         [InlineData("{}}", 1)]
         [InlineData("const int a := false", 1)]
         [InlineData("{const int a := 10\na := 5}", 1)]
+        [InlineData("int => bool", 3)]
+        [InlineData("hello => int", 1)]
+        [InlineData("int => hello", 5)]
        public void Evaluator_Reports_Errors(string text, object expectedValue) {
            var syntaxTree = SyntaxTree.Parse(text);
            var compiler = new Compiler(syntaxTree);

--- a/swifty.tests/Code/Syntax/LexerTest.cs
+++ b/swifty.tests/Code/Syntax/LexerTest.cs
@@ -81,12 +81,20 @@ namespace swifty.tests.Code.Syntax {
                 (SyntaxKind.LogicalAndToken, "&&"),
                 (SyntaxKind.LogicalOrToken, "||"),
                 (SyntaxKind.AssignmentToken, ":="),
-                // (SyntaxKind.XorToken, "^"),
+                (SyntaxKind.XorToken, "^"),
                 (SyntaxKind.LeftParanthesisToken, "("),
                 (SyntaxKind.RightParanthesisToken, ")"),
                 // Keywords
                 (SyntaxKind.TrueKeyword, "True"),
                 (SyntaxKind.FalseKeyword, "False"),
+                (SyntaxKind.ForKeyword, "for"),
+                (SyntaxKind.IfKeyword, "if"),
+                (SyntaxKind.ToKeyword, "to"),
+                (SyntaxKind.WhileKeyword, "while"),
+                (SyntaxKind.BoolKeyword, "bool"),
+                (SyntaxKind.ElseKeyword, "else"),
+                (SyntaxKind.IntKeyword, "int"),
+                (SyntaxKind.ConstKeyword, "const"),
             };
         }
         private static IEnumerable<(SyntaxKind  kind1, string text1, SyntaxKind  kind2, string text2)> GetTokenPair() {


### PR DESCRIPTION
Introduce type cast operator "=>"
Usage : (expression) => (desired type, i.e int, bool)
This operator has the highest precedence